### PR TITLE
Note that gh must be authenticated

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ vim.keymap.set('n', 'gx', require('gx').gx)
 
 [MIT © Josa Gesell](LICENSE)
 
-[^1]: Requires [`gh`](https://cli.github.com/) to be installed.
+[^1]: Requires [`gh`](https://cli.github.com/) to be installed and authenticated, run `gh auth` to authenticate.


### PR DESCRIPTION
Thanks for making this!

I hadn't used `gh` for a long while and the plugin was failing silently when trying to `gx` on a git repo, for example.

This proposed change adds a note to the README that you must authenticate `gh` for those operations to work.